### PR TITLE
fix Uyuni-Server-POOL-x86_64-Media1 repo

### DIFF
--- a/uyuni/Dockerfile
+++ b/uyuni/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.suse.com/bci/bci-init:15.4
 RUN zypper ar -G http://download.opensuse.org/update/leap/15.4/backports/ backports_update_repo
 RUN zypper ar -G http://download.opensuse.org/distribution/leap/15.4/repo/oss/ os_pool_repo
 RUN zypper ar -G http://download.opensuse.org/update/leap/15.4/oss/ os_update_repo
-RUN zypper ar -G http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Server-POOL-x86_64-Media1/ server_pool_repo
+RUN zypper ar -G http://downloadcontent.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Server-POOL-x86_64-Media1/ server_pool_repo
 RUN zypper ar -G http://download.opensuse.org/update/leap/15.4/sle/ sle_update_repo
 RUN zypper ar -G http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/ testing_overlay_devel_repo
 


### PR DESCRIPTION
not sure if it's something temporary  missing, but when I run:
```
docker build --label suma -t uyuni/server:1.0 --add-host=download.opensuse.org:195.135.221.134 .
```
I have this error: 
```
Media source 'http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Server-POOL-x86_64-Media1/' does not contain the desired medium
Abort, retry, ignore? [a/r/i/...? shows all options] (a): a
Problem occurred during or after installation or removal of packages:
Installation has been aborted as directed.
Please see the above error message for a hint.
```

I changed the repo to:
```
http://downloadcontent.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Server-POOL-x86_64-Media1/ server_pool_repo
```
and now the image is built correctly